### PR TITLE
Bugfix/url parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ docs/
 coverage/
 .tmp/
 .grunt/
+.idea/

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ steps.
 - create a test app in the your admin portal at [respoke.io][respoke]
 - turn *off* dev mode
 - create a new blank role (name value is not important)
-- `cp spec/helpers.example.js spec/helpers.js`
+- `cp spec/config.example.json spec/config.json`
 - fill in the information in the `spec/helpers.js` file
 
 There are several commands to run the tests.
@@ -61,7 +61,7 @@ npm run docs
 
 ## License
 
-Copyright 2014, Digium, Inc.
+Copyright 2014-2015, Digium, Inc.
 All rights reserved.
 
 This source code is licensed under The MIT License found in the

--- a/lib/client.js
+++ b/lib/client.js
@@ -8,6 +8,7 @@
  * For all details and documentation:  https://www.respoke.io
  */
 'use strict';
+
 var Promise = require('es6-promise').Promise;
 var nodeify = require('nodeify');
 var events = require('events');
@@ -17,6 +18,7 @@ var io = require('socket.io-client');
 var debug = require('debug')('respoke-client');
 var _ = require('lodash');
 var errors = require('./utils/errors');
+var url = require('url');
 
 /**
  * Determine whether the specified statusCode indicates a successful HTTP request.
@@ -493,15 +495,15 @@ function Client(options) {
             return self.emit('error', new errors.MissingEndpointIdAsAdmin());
         }
 
-        var tokenQS = "?";
+        var tokenQuery = {};
         if (opts['App-Token']) {
-            tokenQS += "&app-token=" + opts['App-Token'];
+            tokenQuery['app-token'] = opts['App-Token'];
         }
         else if (opts['App-Secret']) {
-            tokenQS += "&app-secret=" + opts['App-Secret'];
+            tokenQuery['app-secret'] = opts['App-Secret'];
         }
         else if (opts['Admin-Token']) {
-            tokenQS += "&admin-token=" + opts['Admin-Token'];
+            tokenQuery['admin-token'] = opts['Admin-Token'];
         }
 
         var dataBody = null;
@@ -509,8 +511,11 @@ function Client(options) {
             dataBody = { endpointId: opts.endpointId };
         }
 
-        var nopathUrl = self.baseURL.substring(0, self.baseURL.length - 3); // split off the api version
-        var connectionString = nopathUrl + tokenQS;
+        // Remove the path and set the query to build the Socket.io URL
+        var parsedURL = url.parse(self.baseURL);
+        parsedURL.pathname = '';
+        parsedURL.query = tokenQuery;
+        var connectionString = url.format(parsedURL);
 
         // TODO: refactor out io.connection to use DI for better test coverage
         if (!self.socket) {

--- a/spec/config.example.json
+++ b/spec/config.example.json
@@ -1,14 +1,3 @@
-/*
- * Copyright 2014, Digium, Inc.
- * All rights reserved.
- *
- * This source code is licensed under The MIT License found in the
- * LICENSE file in the root directory of this source tree.
- *
- * For all details and documentation:  https://www.respoke.io
- */
-
-/* Put your own values in here and rename this to `config.json` */
 {
     "baseURL": "https://api.respoke.io/v1",
     "auth": {

--- a/spec/helpers.js
+++ b/spec/helpers.js
@@ -47,8 +47,10 @@ var TestHelpers = {
         }
 
         try {
-            envConfig = JSON.parse(process.env.TEST_CONFIG);
-            _.merge(config, envConfig);
+            if (process.env.TEST_CONFIG) {
+                envConfig = JSON.parse(process.env.TEST_CONFIG);
+                _.merge(config, envConfig);
+            }
         } catch (e) {
             console.error('Error parsing TEST_CONFIG environment variable: ', e);
         }


### PR DESCRIPTION
I started by just trying to fix URL building, and fixed a few other things in the process.

* Adding IntelliJ files to the .gitignore
* Doc and error message fixes for test config
* Replaced the string manipulation in client.js with URL building.

Building URLs by munging strings directly is usually problematic.
This patch makes the URL building more robust by parsing the baseURL and
rebuilding it in order to determine the Socket.io URL.
