### PR TITLE
feature/MER-4009-endpoint-message-ccself-default

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+max_line_length = 100
+
+[*.{js,scss,less,css,jade,json,html}]
+indent_style = space
+indent_size = 4
+
+[package.json]
+indent_size = 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
 - 0.10
+sudo: false
 notifications:
   email:
     recipients:

--- a/lib/client.js
+++ b/lib/client.js
@@ -797,7 +797,8 @@ function Client(options) {
         }
 
         params = _.defaults(params || {}, {
-            type: 'message'
+            type: 'message',
+            ccSelf: true
         });
         return self.wsCall('post', '/messages', params);
     };

--- a/lib/client.js
+++ b/lib/client.js
@@ -788,6 +788,7 @@ function Client(options) {
      * @param {string} params.connectionId optional
      * @param {string} params.message required
      * @param {string} params.type='message' optional
+     * @param {string} params.ccSelf=true optional
      * @auth endpoint, web socket
      */
     self.messages.send = function (params, callback) {


### PR DESCRIPTION
To enable receiving cross app endpoint messages:
- Added ccSelf flag to respoke.messages.send method (MER-4009)

To aid consistent formatting during open source contributions:
- Added .editorconfig for consistent contribution formatting
