### PR TITLE
Add sdk and platform information to requests

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -19,7 +19,14 @@ var debug = require('debug')('respoke-client');
 var _ = require('lodash');
 var errors = require('./utils/errors');
 var url = require('url');
+var packageVersion = require('../package.json').version;
+var os = require('os');
+var osName = require('os-name');
 
+var sdkPart = 'Respoke-Node.js/v' + packageVersion;
+var osPart = osName(os.platform(), os.release());
+var nodePart = 'Node.js/' + process.version;
+var sdkHeader = { 'Respoke-SDK': sdkPart + ' (' + osPart + ') ' + nodePart };
 /**
  * Determine whether the specified statusCode indicates a successful HTTP request.
  *
@@ -264,6 +271,9 @@ function Client(options) {
             json: true,
             headers: self.tokens
         });
+
+        params.headers = _.assign({}, params.headers, sdkHeader);
+
         debug('request', params);
 
         request(params, callback);
@@ -291,7 +301,7 @@ function Client(options) {
 
         var wsBody = {
             url: self.baseURL + urlPath,
-            headers: headers,
+            headers: _.assign({}, headers, sdkHeader),
             data: data
         };
 
@@ -495,7 +505,7 @@ function Client(options) {
             return self.emit('error', new errors.MissingEndpointIdAsAdmin());
         }
 
-        var tokenQuery = {};
+        var tokenQuery = _.assign({}, sdkHeader);
         if (opts['App-Token']) {
             tokenQuery['app-token'] = opts['App-Token'];
         }

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "es6-promise": "^2.1.1",
     "lodash": "^3.9.3",
     "nodeify": "^1.0.0",
+    "os-name": "^1.0.3",
     "request": "^2.40.0",
     "socket.io-client": "^0.9.x"
   }


### PR DESCRIPTION
This adds a new header to HTTP and websocket requests, as well as a query string to the io.connect to identify the Respoke node.js SDK as the client. It will report the version of the sdk, as well as the OS version and the node.js version.

![screen shot 2015-09-18 at 4 55 28 pm](https://cloud.githubusercontent.com/assets/309219/9972150/5a4289b8-5e27-11e5-8617-f8657abf28d4.png)
![screen shot 2015-09-18 at 4 56 35 pm](https://cloud.githubusercontent.com/assets/309219/9972149/5a406886-5e27-11e5-8945-903dd3a8e702.png)
![screen shot 2015-09-18 at 5 03 20 pm](https://cloud.githubusercontent.com/assets/309219/9972148/5a406c78-5e27-11e5-9893-4b92e4e7c13f.png)



