### PR TITLE
Clean up connect errors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,3 +17,6 @@ indent_size = 4
 
 [package.json]
 indent_size = 2
+
+[.git/COMMIT_EDITMSG]
+max_line_length = 72

--- a/lib/client.js
+++ b/lib/client.js
@@ -607,22 +607,12 @@ function Client(options) {
                  */
                 self.emit('error', err);
             });
-            self.socket.on('connect_error', function (err) {
-                debug('event connect_error', self.endpointId, err);
-                /**
-                 * An error occurred while trying to connect.
-                 * @event connect_error
-                 * @property {error} err
-                 */
-                self.emit('connect_error', err);
-            });
-            self.socket.on('connect_timeout', function () {
-                debug('event connect_timeout', self.endpointId);
-                /**
-                 * A connection timeout.
-                 * @event connect_timeout
-                 */
-                self.emit('connect_timeout');
+            self.socket.on('connect_failed', function () {
+                debug('event connect_failed', self.endpointId);
+                // connect_failed is only emitted when there's a timeout, or when
+                // the protocols are misconfigured. Other connection failures come
+                // as error events. emit an error event for a consistent API.
+                self.emit('error', new Error('Socket.io connect failed'));
             });
             self.socket.on('message', function (msg) {
                 debug('event message', self.endpointId, msg);

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "Respoke API client library for Node.js.",
   "main": "index.js",
   "scripts": {
-    "test": "istanbul cover _mocha spec/**/*.spec.js",
-    "functional": "mocha spec/functional/**/*.spec.js",
-    "unit": "mocha spec/unit/**/*.spec.js",
+    "test": "istanbul cover _mocha 'spec/**/*.spec.js'",
+    "functional": "mocha 'spec/functional/**/*.spec.js'",
+    "unit": "mocha 'spec/unit/**/*.spec.js'",
     "debug-test": "DEBUG=respoke-client,respoke-admin npm test",
     "docs": "grunt docs",
     "build-readme": "grunt build"

--- a/spec/unit/client/auth.spec.js
+++ b/spec/unit/client/auth.spec.js
@@ -312,8 +312,7 @@ describe('auth', function () {
                 'reconnect',
                 'reconnecting',
                 'error',
-                'connect_error',
-                'connect_timeout',
+                'connect_failed',
                 'message',
                 'presence',
                 'join',
@@ -332,10 +331,11 @@ describe('auth', function () {
             });
 
             it('assigns the correct number of listeners', function () {
-                respoke.socket.on.callCount.should.equal(expectedListeners.length);
                 expectedListeners.forEach(function (expectedEvent) {
-                    respoke.socket.on.calledWith(expectedEvent).should.equal(true);
+                    respoke.socket.on.calledWith(expectedEvent).should
+                        .equal(true, expectedEvent + ' should have been registered');
                 });
+                respoke.socket.on.callCount.should.equal(expectedListeners.length);
             });
         });
     });


### PR DESCRIPTION
The client was relaying connect_error and connect_timeout socket.io
events, neither of which are events in our version of socket.io.

There is a connect_failed event, but most connections failures are
actually emitted as error events. For consistency, we'll emit
connect_failed as an error through our API.

I also discovered that `npm test` didn't run the unit tests, so I
fixed that.