### PR TITLE
Feature/autoreconnect with app secret

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- "0.12.x"
+- "0.12"
 - "4"
 - "6"
 sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+- "0.10"
 - "0.12"
 - "4"
 - "6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-- "0.10"
 - "0.12"
 - "4"
 - "6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
-- 0.1
+- "0.12.x"
+- "4"
+- "6"
 sudo: required
 notifications:
   email:

--- a/lib/client.js
+++ b/lib/client.js
@@ -189,10 +189,10 @@ function isOk(statusCode) {
  * @class respoke
  * @param {object} options - Optional
  * @param {string} options.appId - Optional
- * @param {object} options['Admin-Token'] - Optional header, if you already authenticated
- * @param {object} options['App-Secret'] - Optional header, from Respoke dev console
- * @param {object} options['App-Token'] - Optional header, if you already authenticated
- * @param {object} options.endpointId - Optional endpointId to use when connecting via web socket
+ * @param {string} options['Admin-Token'] - Optional header, if you already authenticated
+ * @param {string} options['App-Secret'] - Optional header, from Respoke dev console
+ * @param {string} options['App-Token'] - Optional header, if you already authenticated
+ * @param {string} options.endpointId - Optional endpointId to use when connecting via web socket
  * using auth scheme which does not imply an endpointId (i.e. App-Secret)
  * @param {boolean} options.autoreconnect=false - Optional flag to automatically reconnect to
  * respoke if a web socket connection becomes active, then is lost. This will throw an error
@@ -210,18 +210,21 @@ function Client(options) {
      * Boolean indicating whether to keep trying to reinitate a web socket to respoke when
      * using an App-Secret for auth. Defaults false.
      * @type {boolean}
+     * @private
      */
     self.autoreconnect = !!options.autoreconnect;
     /**
      * Milliseconds to wait before attempting to reauthorize with respoke using App-Secret to
      * make a web socket connection.
      * @type {integer} milliseconds
+     * @private
      */
     self.autoreconnectInterval = 1000;
     /**
      * Timeout ID returned from `setTimeout()` when attempting to reauthorize with respoke
      * using App-Secret to make a web socket connection.
      * @type {number} timeoutID
+     * @private
      */
     self.autoreconnectTimeout = null;
     /**
@@ -229,13 +232,16 @@ function Client(options) {
      * @private
      */
     self._attemptAutoreconnect = function _attemptAutoreconnect() {
+        debug('attempting autoreconnect', self._attemptAutoreconnect.callCount);
         self.clearAutoreconnectTimeout();
         self.autoreconnectInterval = self.autoreconnectInterval * 2;
         if (self.autoreconnectInterval > 60000) {
             self.autoreconnectInterval = 60000;
         }
         function onErrorTryAgain() {
-            self.autoreconnectTimeout = setTimeout(self._attemptAutoreconnect, self.autoreconnectInterval);
+            self.autoreconnectTimeout = setTimeout(function () {
+                self._attemptAutoreconnect();
+            }, self.autoreconnectInterval);
         }
         self.auth.connect();
         self.socket.once('error', onErrorTryAgain);
@@ -246,6 +252,7 @@ function Client(options) {
         });
     };
     /**
+     * function to prevent leaks by clearing any reconnection timeouts.
      * @private
      */
     self.clearAutoreconnectTimeout = function clearAutoreconnectTimeout() {
@@ -259,11 +266,6 @@ function Client(options) {
      * @private
      */
     self.socketIOConnectParams = null;
-    /**
-     * Stored endpointId for use when connecting with App-Secret via web socket (when not
-     * a specific endpoint).
-     */
-    self.endpointId = null;
     /**
      * Container object for header tokens.
      * These are used when performing REST or web socket requests to Respoke.
@@ -297,10 +299,11 @@ function Client(options) {
      */
     self.connectionId = null;
     /**
-     * If connected, this is the endpointId.
+     * If connected, this is the endpointId. Stored endpointId for use when connecting
+     * with App-Secret via web socket (when not a specific endpoint).
      * @type {string}
      */
-    self.endpointId = null;
+    self.endpointId = options.endpointId || null;
 
     /**
      * The base respoke api to use. In most circumstances there is no reason
@@ -660,10 +663,12 @@ function Client(options) {
                     return;
                 }
                 if (!self.tokens['App-Secret']) {
-                    self.emit('error', errors.MissingAppSecretDuringAutoreconnect());
+                    self.emit('error', new errors.MissingAppSecretDuringAutoreconnect());
                     return;
                 }
-                self.autoreconnectTimeout = setTimeout(self._attemptAutoreconnect, self.autoreconnectInterval);
+                self.autoreconnectTimeout = setTimeout(function () {
+                    self._attemptAutoreconnect();
+                }, self.autoreconnectInterval);
             });
             self.socket.on('reconnect', function (num) {
                 debug('event reconnect', self.endpointId, num);
@@ -815,11 +820,12 @@ function Client(options) {
      * @param {function} callback (err)
      */
     self.close = function (callback) {
+        self.autoreconnect = false;
+
         if (callback) {
             nodeify(self.close(), callback);
             return;
         }
-
         return new Promise(function (resolve, reject) {
             if (self.socket) {
                 self.socket.disconnect();

--- a/lib/client.js
+++ b/lib/client.js
@@ -135,7 +135,9 @@ function isOk(statusCode) {
  *      var admin = new Respoke({
  *          // from the Respoke developer console under one of your apps
  *          appId: "XXXX-XXX-XXXXX-XXXX",
- *          'App-Secret': 'XXXX-XXXXX-XXX-XXXXXXXX'
+ *          'App-Secret': 'XXXX-XXXXX-XXX-XXXXXXXX',
+ *          // if the respoke socket is lost, keep trying to reconnect automatically
+ *          autoreconnect: true
  *      });
  *
  *      // connect to respoke
@@ -190,6 +192,11 @@ function isOk(statusCode) {
  * @param {object} options['Admin-Token'] - Optional header, if you already authenticated
  * @param {object} options['App-Secret'] - Optional header, from Respoke dev console
  * @param {object} options['App-Token'] - Optional header, if you already authenticated
+ * @param {object} options.endpointId - Optional endpointId to use when connecting via web socket
+ * using auth scheme which does not imply an endpointId (i.e. App-Secret)
+ * @param {boolean} options.autoreconnect=false - Optional flag to automatically reconnect to
+ * respoke if a web socket connection becomes active, then is lost. This will throw an error
+ * when attempting to reconnect if specified without an App-Secret.
  * @param {string} options.baseURL=https://api.respoke.io/v1 - Optional
  * @param {object} options.socket - Optional, overrides the default socket.io client
  */
@@ -199,6 +206,64 @@ function Client(options) {
     events.EventEmitter.call(this);
     options = options || { };
 
+    /**
+     * Boolean indicating whether to keep trying to reinitate a web socket to respoke when
+     * using an App-Secret for auth. Defaults false.
+     * @type {boolean}
+     */
+    self.autoreconnect = !!options.autoreconnect;
+    /**
+     * Milliseconds to wait before attempting to reauthorize with respoke using App-Secret to
+     * make a web socket connection.
+     * @type {integer} milliseconds
+     */
+    self.autoreconnectInterval = 1000;
+    /**
+     * Timeout ID returned from `setTimeout()` when attempting to reauthorize with respoke
+     * using App-Secret to make a web socket connection.
+     * @type {number} timeoutID
+     */
+    self.autoreconnectTimeout = null;
+    /**
+     * Internal handler for reauthing and connecting via web socket to respoke with App-Secret.
+     * @private
+     */
+    self._attemptAutoreconnect = function _attemptAutoreconnect() {
+        self.clearAutoreconnectTimeout();
+        self.autoreconnectInterval = self.autoreconnectInterval * 2;
+        if (self.autoreconnectInterval > 60000) {
+            self.autoreconnectInterval = 60000;
+        }
+        function onErrorTryAgain() {
+            self.autoreconnectTimeout = setTimeout(self._attemptAutoreconnect, self.autoreconnectInterval);
+        }
+        self.auth.connect();
+        self.socket.once('error', onErrorTryAgain);
+        self.socket.once('connect', function onAutoreconnectConnectEvent() {
+            self.socket.removeListener('error', onErrorTryAgain);
+            self.clearAutoreconnectTimeout();
+            self.autoreconnectInterval = 1000;
+        });
+    };
+    /**
+     * @private
+     */
+    self.clearAutoreconnectTimeout = function clearAutoreconnectTimeout() {
+        if (self.autoreconnectTimeout) {
+            clearTimeout(self.autoreconnectTimeout);
+            self.autoreconnectTimeout = null;
+        }
+    };
+    /**
+     * socketIOConnectParams are re-used when doing an autoreconnect.
+     * @private
+     */
+    self.socketIOConnectParams = null;
+    /**
+     * Stored endpointId for use when connecting with App-Secret via web socket (when not
+     * a specific endpoint).
+     */
+    self.endpointId = null;
     /**
      * Container object for header tokens.
      * These are used when performing REST or web socket requests to Respoke.
@@ -500,9 +565,10 @@ function Client(options) {
             'Admin-Token': self.tokens['Admin-Token'],
             'App-Secret': self.tokens['App-Secret'],
             'App-Token': self.tokens['App-Token'],
-            endpointId: null,
-            connectParams: {
-                'force new connection': true
+            endpointId: self.endpointId,
+            connectParams: self.socketIOConnectParams || {
+                'force new connection': true,
+                'max reconnection attempts': Infinity
             }
         });
 
@@ -528,10 +594,18 @@ function Client(options) {
             tokenQuery['admin-token'] = opts['Admin-Token'];
         }
 
+        // save socket.io connect params for reconnect and re-respoke auth, if autoreconnect enabled
+        if (self.autoreconnect && !self.socketIOConnectParams) {
+            self.socketIOConnectParams = opts.connectParams;
+        }
+
         var dataBody = {};
 
         if (opts.endpointId) {
             dataBody.endpointId = opts.endpointId;
+            if (!self.endpointId) {
+                self.endpointId = opts.endpointId; // save endpointId
+            }
         }
 
         if (opts.clientType) {
@@ -579,6 +653,17 @@ function Client(options) {
                  * @event disconnect
                  */
                 self.emit('disconnect');
+
+                self.clearAutoreconnectTimeout();
+
+                if (!self.autoreconnect) {
+                    return;
+                }
+                if (!self.tokens['App-Secret']) {
+                    self.emit('error', errors.MissingAppSecretDuringAutoreconnect());
+                    return;
+                }
+                self.autoreconnectTimeout = setTimeout(self._attemptAutoreconnect, self.autoreconnectInterval);
             });
             self.socket.on('reconnect', function (num) {
                 debug('event reconnect', self.endpointId, num);
@@ -588,6 +673,7 @@ function Client(options) {
                  * @property {number} num
                  */
                 self.emit('reconnect', num);
+                self.clearAutoreconnectTimeout();
             });
             self.socket.on('reconnecting', function (num) {
                 debug('event reconnecting', self.endpointId, num);

--- a/lib/utils/errors.js
+++ b/lib/utils/errors.js
@@ -137,3 +137,21 @@ function SocketErrorResponseFromServer(response, method, path) {
 util.inherits(SocketErrorResponseFromServer, Error);
 
 exports.SocketErrorResponseFromServer = SocketErrorResponseFromServer;
+
+/**
+ * Error thrown when attempting to perform autoreconnect of web socket with App-Secret
+ * but there is no App-Secret.
+ *
+ * @constructor
+ * @augments Error
+ */
+function MissingAppSecretDuringAutoreconnect() {
+    Error.call(this);
+    Error.captureStackTrace(this, this.constructor);
+    this.message = '[respoke] missing App-Secret during autoreconnect';
+    this.name = 'MissingAppSecretDuringAutoreconnect';
+}
+
+util.inherits(MissingAppSecretDuringAutoreconnect, Error);
+
+exports.MissingAppSecretDuringAutoreconnect = MissingAppSecretDuringAutoreconnect;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "respoke-admin",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "description": "Respoke API client library for Node.js.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "nock": "^2.3.0",
     "should": "^6.0.3",
     "sinon": "^1.10.3",
+    "socket.io": "^0.9.17",
     "uuid": "^2.0.1"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "istanbul cover _mocha 'spec/**/*.spec.js'",
     "functional": "mocha 'spec/functional/**/*.spec.js'",
     "unit": "mocha 'spec/unit/**/*.spec.js'",
-    "debug-test": "DEBUG=respoke-client,respoke-admin npm test",
+    "debug-test": "DEBUG=respoke-* npm test",
     "docs": "grunt docs",
     "build-readme": "grunt build"
   },
@@ -33,7 +33,7 @@
       "email": "me@dan-jenkins.co.uk"
     },
     {
-      "name": "Jeff Parrish",
+      "name": "Jeff H. Parrish",
       "email": "jeffhparrish@gmail.com"
     },
     {

--- a/spec/unit/client/autoreconnect.spec.js
+++ b/spec/unit/client/autoreconnect.spec.js
@@ -1,0 +1,71 @@
+'use strict';
+var Respoke = require('../../../index');
+var assert = require('assert');
+var uuid = require('uuid');
+var nock = require('nock');
+var sinon = require('sinon');
+var debug = require('debug')('respoke-tests-autoreconnect');
+var IO = require('socket.io');
+var io;
+
+describe.only('autoreconnect', function () {
+    beforeEach(function (done) {
+        io = IO.listen(5050, function (err) {
+            if (err) {
+                done(err);
+                return;
+            }
+            debug('socket.io server up');
+            done();
+        }); // this port seems halfway decent
+        io.sockets.on('connection', function (socket) {
+            debug('socket connection', socket.id);
+            socket.on('reconnect', function () {
+                debug('socket reconnect', socket.id);
+            });
+
+            socket.on('disconnect', function () {
+                debug('socket disconnect', socket.id);
+            });
+        });
+    });
+    afterEach(function () {
+        io.server.close();
+        io = null;
+    });
+
+    describe('when creating a client without specifying autoreconnect or specifying falsey', function () {
+        it('has autoreconnect=false', function () {
+            assert.equal(new Respoke().autoreconnect, false);
+            assert.equal(new Respoke({ autoreconnect: false }).autoreconnect, false);
+            assert.equal(new Respoke({ autoreconnect: 0 }).autoreconnect, false);
+        });
+        it('does not attempt to reconnect after a socket diconnect');
+    });
+    describe('when creating a client specifying truthy autoreconnect', function () {
+        it('has autoreconnect=true', function () {
+            assert.equal(new Respoke({ autoreconnect: true }).autoreconnect, true);
+            assert.equal(new Respoke({ autoreconnect: 'yes' }).autoreconnect, true);
+            assert.equal(new Respoke({ autoreconnect: 1 }).autoreconnect, true);
+        });
+    });
+    describe('when a socket disconnects and autoreconnect is specified, but App-Secret is empty', function () {
+        it('emits an error', function () {
+            var respoke = new Respoke({ autoreconnect: true });
+            assert.equal(respoke.autoreconnect, true);
+
+        });
+    });
+    describe('when the socket disconnects and autoreconnect and App-Secret are set on the client', function () {
+        it('calls the internal reconnect handler after the timeout');
+        it('resets the reconnect timeout upon disconnect');
+        it('exponentionally iterates the reconnect timer up to 60 seconds');
+
+    });
+    describe('when the socket is diconnected by calling disconnect', function () {
+        it('does not try to autoreconnect');
+    });
+    describe('when connect is called', function () {
+        it('clears the reconnect tracking variables and timer');
+    });
+});

--- a/spec/unit/client/autoreconnect.spec.js
+++ b/spec/unit/client/autoreconnect.spec.js
@@ -1,71 +1,296 @@
 'use strict';
-var Respoke = require('../../../index');
+var _Respoke = require('../../../index');
+var errors = require('../../../lib/utils/errors');
 var assert = require('assert');
-var uuid = require('uuid');
-var nock = require('nock');
-var sinon = require('sinon');
+var _sinon = require('sinon');
+var sinon;
 var debug = require('debug')('respoke-tests-autoreconnect');
 var IO = require('socket.io');
+var fakeBase = 'http://localhost:5050/v1';
 var io;
+var clientSocket;
 
-describe.only('autoreconnect', function () {
-    beforeEach(function (done) {
-        io = IO.listen(5050, function (err) {
-            if (err) {
-                done(err);
-                return;
+function Respoke(params) {
+    var instance = new _Respoke(params);
+    instance.baseURL = fakeBase;
+    return instance;
+}
+
+function startSocketIOServer(done) {
+    io = IO.listen(5050, function (err) { // this port seems halfway decent
+        if (err) {
+            done(err);
+            return;
+        }
+        debug('socket.io server up');
+        done();
+    });
+    io.sockets.on('connection', function (socket) {
+        debug('socket connection', socket.id);
+        clientSocket = socket;
+
+        socket.on('reconnect', function () {
+            debug('socket reconnect', socket.id);
+        });
+
+        socket.on('disconnect', function () {
+            debug('socket disconnect', socket.id);
+        });
+
+        socket.on('post', function (post, callback) {
+            debug('socket receive post', post);
+            post = JSON.parse(post);
+            if (callback) {
+                if (post.url === 'http://localhost:5050/v1/connections') {
+                    callback({
+                        endpointId: post.data.endpointId,
+                        connectionId: 'some-connection-id'
+                    });
+                } else {
+                    callback();
+                }
             }
-            debug('socket.io server up');
-            done();
-        }); // this port seems halfway decent
-        io.sockets.on('connection', function (socket) {
-            debug('socket connection', socket.id);
-            socket.on('reconnect', function () {
-                debug('socket reconnect', socket.id);
-            });
-
-            socket.on('disconnect', function () {
-                debug('socket disconnect', socket.id);
-            });
         });
     });
-    afterEach(function () {
-        io.server.close();
-        io = null;
+    io.set('authorization', function (handshake, next) {
+        next(null, true);
+    });
+}
+
+describe('autoreconnect', function () {
+    var respoke;
+    // Main thing here is to make sure the web socket always connects.
+    beforeEach(function (done) {
+        sinon = _sinon.sandbox.create();
+        startSocketIOServer(done);
+    });
+    afterEach(function (done) {
+        if (!respoke) {
+            done();
+            return;
+        }
+        if (!respoke.socket) {
+            respoke = null;
+            done();
+            return;
+        }
+        if (!respoke.socket.socket.connected) {
+            respoke = null;
+            done();
+            return;
+        }
+        respoke.close(done);
+        respoke = null;
+    });
+    afterEach(function (done) {
+        io.server.close(function () {
+            sinon.restore();
+            sinon = null;
+            io = null;
+            done();
+        });
     });
 
     describe('when creating a client without specifying autoreconnect or specifying falsey', function () {
-        it('has autoreconnect=false', function () {
-            assert.equal(new Respoke().autoreconnect, false);
-            assert.equal(new Respoke({ autoreconnect: false }).autoreconnect, false);
-            assert.equal(new Respoke({ autoreconnect: 0 }).autoreconnect, false);
+        describe('in all scenarios', function () {
+            it('has autoreconnect=false', function () {
+                assert.equal(Respoke().autoreconnect, false);
+                assert.equal(Respoke({ autoreconnect: false }).autoreconnect, false);
+                assert.equal(Respoke({ autoreconnect: 0 }).autoreconnect, false);
+            });
         });
-        it('does not attempt to reconnect after a socket diconnect');
+        describe('with App-Secret', function () {
+            this.timeout(5000);
+            it('does not attempt to reconnect after a socket disconnect', function (done) {
+                respoke = Respoke();
+                sinon.spy(respoke.auth, 'connect');
+                sinon.spy(respoke, '_attemptAutoreconnect');
+
+                respoke.auth.connect({ 'App-Secret': 'asdf', endpointId: 'chris' });
+                respoke.once('connect', function () {
+                    assert.equal(respoke.auth.connect.callCount, 1);
+                    // server disconnects
+                    clientSocket.disconnect();
+                    setTimeout(function () {
+                        assert.equal(respoke._attemptAutoreconnect.called, false);
+                        assert.equal(respoke.auth.connect.callCount, 1); // same as earlier
+                        done();
+                    }, 2200);
+                });
+            });
+        });
+        describe('without App-Secret', function () {
+            this.timeout(5000);
+            it('does not attempt to reconnect after a socket disconnect', function (done) {
+                respoke = Respoke({ autoreconnect: false });
+                sinon.spy(respoke.auth, 'connect');
+                sinon.spy(respoke, '_attemptAutoreconnect');
+
+                respoke.auth.connect({ 'App-Token': 'beef-wellington', endpointId: 'elbert' });
+                respoke.once('connect', function () {
+                    assert.equal(respoke.auth.connect.callCount, 1);
+                    clientSocket.disconnect();
+                    setTimeout(function () {
+                        assert.equal(respoke._attemptAutoreconnect.called, false);
+                        assert.equal(respoke.auth.connect.callCount, 1); // same
+                        done();
+                    }, 2200);
+                });
+            });
+        });
     });
     describe('when creating a client specifying truthy autoreconnect', function () {
         it('has autoreconnect=true', function () {
-            assert.equal(new Respoke({ autoreconnect: true }).autoreconnect, true);
-            assert.equal(new Respoke({ autoreconnect: 'yes' }).autoreconnect, true);
-            assert.equal(new Respoke({ autoreconnect: 1 }).autoreconnect, true);
+            assert.equal(Respoke({ autoreconnect: true }).autoreconnect, true);
+            assert.equal(Respoke({ autoreconnect: 'yes' }).autoreconnect, true);
+            assert.equal(Respoke({ autoreconnect: 1 }).autoreconnect, true);
         });
     });
     describe('when a socket disconnects and autoreconnect is specified, but App-Secret is empty', function () {
-        it('emits an error', function () {
-            var respoke = new Respoke({ autoreconnect: true });
+        it('emits an error', function (done) {
+            respoke = Respoke({ autoreconnect: true });
             assert.equal(respoke.autoreconnect, true);
-
+            respoke.auth.connect({ 'App-Token': 'groggy-dolphins' });
+            respoke.once('connect', function () {
+                clientSocket.disconnect();
+            });
+            respoke.once('error', function (err) {
+                console.log(err.message, err.stack)
+                assert(err instanceof errors.MissingAppSecretDuringAutoreconnect);
+                done();
+            });
         });
     });
-    describe('when the socket disconnects and autoreconnect and App-Secret are set on the client', function () {
-        it('calls the internal reconnect handler after the timeout');
-        it('resets the reconnect timeout upon disconnect');
-        it('exponentionally iterates the reconnect timer up to 60 seconds');
+    // main test of the autoreconnect functionality
+    describe('when the socket disconnects unexpectedly and autoreconnect and App-Secret are set on the client', function () {
+        it('calls the internal reconnect handler after the timeout', function (done) {
+            this.timeout(5000);
+            respoke = Respoke({
+                autoreconnect: true,
+                'App-Secret': 'rainbow-dash',
+                endpointId: 'bilton'
+            });
+            var spy = sinon.spy(respoke, '_attemptAutoreconnect');
+            respoke.auth.connect();
+            assert.equal(spy.callCount, 0);
+            respoke.once('connect', function () {
+                assert.equal(spy.callCount, 0);
+                // Important that there is no timeout before calling disconnect,
+                // so we know the state is clean and we are already (hopefully)
+                // connected.
+                // It should add a timer and then reconnect.
+                assert(!respoke.autoreconnectTimeout);
+                // server disconnects the client web socket
+                clientSocket.disconnect();
+
+                setTimeout(function () {
+                    assert(respoke.autoreconnectTimeout); // indicates now waiting to reconnect
+                    assert.equal(spy.callCount, 0);
+                    respoke.once('connect', function () {
+                        assert.equal(spy.callCount, 1);
+                        done();
+                    });
+                }, 300);
+            });
+        });
+        it('resets the reconnect timeout after a reconnect', function (done) {
+            respoke = Respoke({
+                autoreconnect: true,
+                'App-Secret': 'rainbow-bright',
+                endpointId: 'muddy-waters'
+            });
+            sinon.spy(respoke, 'clearAutoreconnectTimeout');
+            respoke.auth.connect();
+            assert.equal(respoke.clearAutoreconnectTimeout.callCount, 0);
+            respoke.once('connect', function () {
+                assert.equal(respoke.clearAutoreconnectTimeout.callCount, 0);
+                clientSocket.disconnect();
+                assert.equal(respoke.clearAutoreconnectTimeout.callCount, 0);
+                respoke.once('connect', function () {
+                    assert.equal(respoke.clearAutoreconnectTimeout.callCount, 3);
+                    done();
+                });
+            });
+        });
+        it('exponentionally iterates the reconnect timer up to 60 seconds', function (done) {
+            respoke = Respoke({
+                autoreconnect: true,
+                'App-Secret': 'elephant-tusks',
+                endpointId: 'arty-too-smarty'
+            });
+            respoke.auth.connect();
+            sinon.stub(respoke.auth, 'connect', function () {});
+            respoke.once('connect', function () {
+                io.server.close();
+                clientSocket.disconnect();
+                // give it a little time to shut down
+                setTimeout(function () {
+                    assert.equal(respoke.autoreconnectInterval, 1000);
+                    respoke._attemptAutoreconnect();
+                    assert.equal(respoke.autoreconnectInterval, 2000);
+                    respoke._attemptAutoreconnect();
+                    assert.equal(respoke.autoreconnectInterval, 4000);
+                    respoke._attemptAutoreconnect();
+                    assert.equal(respoke.autoreconnectInterval, 8000);
+                    respoke._attemptAutoreconnect();
+                    assert.equal(respoke.autoreconnectInterval, 16000);
+                    respoke._attemptAutoreconnect();
+                    assert.equal(respoke.autoreconnectInterval, 32000);
+                    respoke._attemptAutoreconnect();
+                    assert.equal(respoke.autoreconnectInterval, 60000);
+                    respoke._attemptAutoreconnect();
+                    assert.equal(respoke.autoreconnectInterval, 60000);
+                    done();
+                }, 250);
+            });
+        });
 
     });
-    describe('when the socket is diconnected by calling disconnect', function () {
-        it('does not try to autoreconnect');
+    describe('when the socket is disconnected by calling close()', function () {
+        it('does not try to autoreconnect', function (done) {
+            this.timeout(10000);
+            respoke = Respoke({
+                autoreconnect: true,
+                'App-Secret': 'elephant-tusks',
+                endpointId: 'arty-too-smarty'
+            });
+            respoke.auth.connect();
+            sinon.spy(respoke, '_attemptAutoreconnect');
+            respoke.once('connect', function () {
+                respoke.close();
+                setTimeout(function () {
+                    assert.equal(respoke.autoreconnectInterval, 1000);
+                    assert.equal(respoke.autoreconnectTimeout, null);
+                    assert.equal(respoke._attemptAutoreconnect.callCount, 0);
+                    setTimeout(function () {
+                        assert.equal(respoke.autoreconnectInterval, 1000);
+                        assert.equal(respoke.autoreconnectTimeout, null);
+                        assert.equal(respoke._attemptAutoreconnect.callCount, 0);
+                        assert.equal(respoke.socket.socket.connected, false);
+                        done();
+                    }, 2000);
+                }, 500);
+            });
+        });
     });
-    describe('when connect is called', function () {
-        it('clears the reconnect tracking variables and timer');
+    describe('when connect is called the second time', function () {
+        it('clears the reconnect tracking variables and timer', function (done) {
+            respoke = Respoke({
+                autoreconnect: true,
+                'App-Secret': 'a-b-c-d',
+                endpointId: 'billy-mays'
+            });
+            sinon.spy(respoke, 'clearAutoreconnectTimeout');
+            assert.equal(respoke.clearAutoreconnectTimeout.called, false);
+            respoke.auth.connect();
+            respoke.once('connect', function () {
+                assert.equal(respoke.clearAutoreconnectTimeout.callCount, 0);
+                clientSocket.disconnect();
+                respoke.once('connect', function () { // reconnection
+                    assert.equal(respoke.clearAutoreconnectTimeout.callCount, 3);
+                    done();
+                });
+            });
+        });
     });
 });


### PR DESCRIPTION
After a long-ish period of respoke being unavailable (network issues on client, for example), the socket.io heartbeat/reconnect finally times out and respoke (and/or the client), will tear down the connection's session.

Previously the consumer of `respoke-admin` had to implement reconnection logic. This pull request implements opt-in automatic reconnections *when using App-Secret*.

sample pseudocode reconnection, the old way:

```js
var respoke = new Respoke({ 'App-Secret': 'asdf-jkl' });
// ...
var connectionTimeout; // returned from `setTimeout()`
var nextConnectionRetry = 1000;
respoke.auth.connect();
respoke.once('connect', function () {
  // do stuff now that we are connected
  // join groups, log connected, etc
});
respoke.on('disconnect', function () {
  // user-implemented reconnection logic
  nextConnectionRetry = nextConnectionRetry * 2;
  connectionTimeout = setTimeout(function () {
    respoke.auth.connect();
  }, nextConnectionRetry);
  var connectionFailure = function (err) {
     console.error('reconnection failure', err);
     nextConnectionRetry = nextConnectionRetry * 2;
     connectionTimeout = setTimeout(function () {
        respoke.auth.connect();
     }, nextConnectionRetry);
  };
  respoke.once('error', connectionFailure);
  respoke.once('connect', function () {
    // ok we connected again
    // join groups, log connected, etc
    clearTimeout(connectionTimeout);
    connectionTimeout = null;
    nextConnectionRetry = 1000;
    respoke.removeEventListener('error', connectionFailure);
  });
});
```

sample reconnection, the new way:

```js
var Respoke = require('respoke-admin');
var respoke = new Respoke({ 'App-Secret': 'asdf-jkl', autoreconnect: true });
respoke.auth.connect();
respoke.on('connect', function () {
   // join groups, log connected, etc
});
```