### PR TITLE
Prevent RangeError inside ws package

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,6 @@
     "nodeify": "^1.0.0",
     "os-name": "^1.0.3",
     "request": "^2.40.0",
-    "socket.io-client": "^0.9.16"
+    "socket.io-client": "respoke/socket.io-client#0.9-ws1.x"
   }
 }


### PR DESCRIPTION
Node >= 6 does not play well with `ws` < 1.

https://github.com/websockets/ws/issues/778

@chadxz created an updated fork of socket.io-client, which wraps `ws@1`:

https://github.com/respoke/socket.io-client#0.9-ws1.x

I thought I added it to PR #15 but it is nowhere to be found.